### PR TITLE
Replace all 'portfolio' in code with 'members'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -219,7 +219,7 @@ collections:
   publications:
     output: true
     permalink: /:collection/:path/
-  portfolio:
+  members:
     output: true
     permalink: /:collection/:path/
   talks:
@@ -265,10 +265,10 @@ defaults:
       author_profile: true
       share: true
       comments: true
-  # _portfolio
+  # _members
   - scope:
       path: ""
-      type: portfolio
+      type: members
     values:
       layout: single
       author_profile: true

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,7 +15,7 @@ main:
     url: /teaching/    
     
   - title: "Members"
-    url: /portfolio/
+    url: /members/
         
   - title: "Blog Posts"
     url: /year-archive/

--- a/_members/members-1.md
+++ b/_members/members-1.md
@@ -1,7 +1,7 @@
 ---
 title: "Portfolio item number 1"
 excerpt: "Short description of portfolio item number 1<br/><img src='/images/500x300.png'>"
-collection: portfolio
+collection: members
 ---
 
 This is an item in your portfolio. It can be have images or nice text. If you name the file .md, it will be parsed as markdown. If you name the file .html, it will be parsed as HTML. 

--- a/_pages/portfolio.html
+++ b/_pages/portfolio.html
@@ -1,13 +1,13 @@
 ---
 layout: archive
 title: "Members"
-permalink: /portfolio/
+permalink: /members/
 author_profile: true
 ---
 
 {% include base_path %}
 
 
-{% for post in site.portfolio %}
+{% for post in site.members %}
   {% include archive-single.html %}
 {% endfor %}


### PR DESCRIPTION
Replace all instances of 'portfolio' with 'members' in the codebase.

* Update `_config.yml` to change `portfolio` to `members` under the `collections` and `defaults` sections.
* Update `_data/navigation.yml` to change the `url` for the "Members" title from `/portfolio/` to `/members/`.
* Update `_pages/portfolio.html` to change the `title` to "Members", update the `permalink` to `/members/`, and update the loop to iterate over `site.members` instead of `site.portfolio`.
* Rename `_portfolio/portfolio-1.md` to `_members/members-1.md` and update the `collection` field in the front matter from `portfolio` to `members`.

